### PR TITLE
skip nodegroup

### DIFF
--- a/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
+++ b/cluster-autoscaler/cloudprovider/hetzner/hetzner_manager.go
@@ -213,6 +213,11 @@ func (m *hetznerManager) serverForNode(node *apiv1.Node) (*hcloud.Server, error)
 		nodeIdOrName = node.Name
 	}
 
+	nodeGroupId, exists := node.Labels["autoscaling.k8s.io/nodegroup"]
+	if exists && nodeGroupId == "skip" {
+		return nil, nil
+	}
+
 	server, err := m.cachedServers.getServer(nodeIdOrName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get servers for node %s error: %v", node.Name, err)


### PR DESCRIPTION
skip nodes with label autoscaling.k8s.io/nodegroup=skip (for hetzner robot nodes)